### PR TITLE
feat: build reconcile binary into image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -8,6 +8,7 @@ RUN go mod download
 
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o popofinder ./cmd/server
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o reconcile ./cmd/reconcile
 RUN CGO_ENABLED=0 GOOS=linux go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.18.1 \
     && find /go/bin -name migrate -type f | head -1 | xargs -I{} cp {} /build/migrate
 
@@ -15,6 +16,7 @@ RUN CGO_ENABLED=0 GOOS=linux go install -tags 'postgres' github.com/golang-migra
 FROM gcr.io/distroless/static-debian12
 
 COPY --from=builder /build/popofinder /popofinder
+COPY --from=builder /build/reconcile /reconcile
 COPY --from=builder /build/migrate /migrate
 COPY migrations /migrations
 


### PR DESCRIPTION
## Summary
- `dockerfile` 新增 build `cmd/reconcile` → `/reconcile`,與 `/popofinder`、`/migrate` 一起進 runtime image。
- 目的:讓 blog 來源回填工具能用**同一個 image** 以 k8s Job 跑,沿用 migrate init-container 已配置的 `DATABASE_URL`。distroless runtime 無 shell,故工具必須以 binary 形式打包進 image 才能在叢集內執行。

## Verification
- 本機交叉編譯驗證:`CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/reconcile` 成功(static arm64 ELF)。
- 不改任何既有 binary / 程式行為,只多打包一支工具。

🤖 Generated with [Claude Code](https://claude.com/claude-code)