### PR TITLE
feat: 來源網址改為可點擊連結

### DIFF
--- a/internal/linebot/template/doctor.go
+++ b/internal/linebot/template/doctor.go
@@ -94,7 +94,15 @@ func doctorBubble(p database.MedicalPersonnel) map[string]any {
 
 	bodyContents := []any{cityRow, hospitalRow, deptRow, eduRow, sourceRow, verifyRow}
 	if p.SourceURL.Valid && p.SourceURL.String != "" {
-		urlRow := row("學歷佐證", p.SourceURL.String, map[string]any{"wrap": true})
+		urlRow := row("學歷佐證", "點此查看來源", map[string]any{
+			"wrap":  true,
+			"color": "#0066CC",
+			"action": map[string]any{
+				"type":  "uri",
+				"label": "查看來源",
+				"uri":   p.SourceURL.String,
+			},
+		})
 		urlRow["margin"] = "md"
 		bodyContents = append(bodyContents, urlRow)
 	}
@@ -116,10 +124,10 @@ func doctorBubble(p database.MedicalPersonnel) map[string]any {
 			"backgroundColor": "#F0F8FF",
 		},
 		"body": map[string]any{
-			"type":             "box",
-			"layout":           "vertical",
-			"contents":         bodyContents,
-			"backgroundColor":  "#FFFFFF",
+			"type":            "box",
+			"layout":          "vertical",
+			"contents":        bodyContents,
+			"backgroundColor": "#FFFFFF",
 		},
 	}
 }

--- a/internal/linebot/template/doctor_test.go
+++ b/internal/linebot/template/doctor_test.go
@@ -26,6 +26,12 @@ func TestDoctorBubbleShowsSourceVerificationAndURL(t *testing.T) {
 			t.Fatalf("card JSON missing %q: %s", want, s)
 		}
 	}
+	// SourceURL should render as a tappable uri action, not raw text.
+	for _, want := range []string{`"type":"uri"`, `"uri":"https://example.com/doc"`, "點此查看來源"} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("card JSON missing link affordance %q: %s", want, s)
+		}
+	}
 }
 
 func TestDoctorBubbleOmitsSourceURLWhenEmpty(t *testing.T) {


### PR DESCRIPTION
## 變更

醫師卡片(Flex Message)的「學歷佐證」列原本直接把 `source_url` 當作純文字顯示一長串網址。改為:

- 顯示文字改為「點此查看來源」,上藍色 `#0066CC`
- text node 掛上 `action: { type: "uri", uri: <source_url> }`,在 LINE 內點擊即可開啟來源連結
- 原始網址保留在 action 內,不再佔版面

## 測試

- 強化 `TestDoctorBubbleShowsSourceVerificationAndURL`,驗證渲染出 uri action 與連結文字
- `go test ./...` ✅ / `go build ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)